### PR TITLE
New flag added in sh2proxy.ini to force fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Windowed = 1
 # (default 0)
 Borderless = 1
 
+# Force borderless even on fullscreen (Windows 10 Fix)
+ForceBorderless = 1
+
 # works with bordered windows too
 # (default 0)
 PositionX = 0

--- a/SH2Proxy/SH2Patcher.cpp
+++ b/SH2Proxy/SH2Patcher.cpp
@@ -106,6 +106,7 @@ bool SH2Patcher::Init()
 	this->bVideoWindowed = (GetPrivateProfileInt("Video", "Windowed", 0, ".\\sh2proxy.ini") == 1);
 
 	this->bWindowBorderless = (GetPrivateProfileInt("Window", "Borderless", 0, ".\\sh2proxy.ini") == 1);
+	this->bForceWindowBorderless = (GetPrivateProfileInt("Window", "ForceBorderless", 0, ".\\sh2proxy.ini") == 1);
 	this->dwWindowX = GetPrivateProfileInt("Window", "PositionX", 0, ".\\sh2proxy.ini");
 	this->dwWindowY = GetPrivateProfileInt("Window", "PositionY", 0, ".\\sh2proxy.ini");
 
@@ -298,7 +299,7 @@ bool SH2Patcher::PatchCode()
 	memcpy(windowedPatch + 0xB, &this->dwWindowY, 4);
 	memcpy(windowedPatch + 0x10, &this->dwWindowX, 4);
 
-	if (this->bVideoWindowed && this->bWindowBorderless) // set CreateWindowExA exStyle param to 0x80000000 (WS_POPUP)
+	if ((this->bVideoWindowed && this->bWindowBorderless) || this->bForceWindowBorderless ) // set CreateWindowExA exStyle param to 0x80000000 (WS_POPUP)
 		windowedPatch[0x18] = 0x80;
 
 	// patch window code to show gameTitle above as window title

--- a/SH2Proxy/SH2Patcher.h
+++ b/SH2Proxy/SH2Patcher.h
@@ -13,6 +13,8 @@ private:
 	bool bVideoWindowed;
 
 	bool bWindowBorderless;
+	bool bForceWindowBorderless;
+
 	int dwWindowX;
 	int dwWindowY;
 


### PR DESCRIPTION
Fixes #9 

Added `ForceBorderless` flag to the ini to fix the Windows 10 fullscreen with borders issue.